### PR TITLE
Fix bug when flagging uncovered cells and flagged cells

### DIFF
--- a/src/ui/game_board.cpp
+++ b/src/ui/game_board.cpp
@@ -224,7 +224,12 @@ namespace GameUI {
                         }
                     } else if (e.mouse().button == Mouse::Right) {
                         game_is_done = board_controller.flag(selected_row, selected_col);
-                        game_board[selected_row][selected_col].symbol = CellSymbol::Flag;
+                        if (board_controller.get_cover(selected_row, selected_col) == GameLogic::Board::Cover::Flagged) {
+                            game_board[selected_row][selected_col].symbol = CellSymbol::Flag;
+                        } else if (board_controller.get_cover(selected_row, selected_col) == GameLogic::Board::Cover::Covered) {
+                            game_board[selected_row][selected_col].symbol = CellSymbol::Empty;
+                        }
+                        
                     }
                 }
             }


### PR DESCRIPTION
**Provide a summary of what you did**
Fixed a bug when flagging a board cells, where already flagged cells weren't getting unflagged and other cells were getting overwritten.
